### PR TITLE
Update UMS3.h - VBAT_ADC_PIN to ALS_ADC_CHANNEL in float getLightSens…

### DIFF
--- a/src/UMS3.h
+++ b/src/UMS3.h
@@ -174,7 +174,7 @@ public:
     uint32_t raw = adc1_get_raw(ALS_ADC_CHANNEL);
     uint32_t millivolts = esp_adc_cal_raw_to_voltage(raw, &adc_cal);
 #else
-    uint32_t millivolts = analogReadMilliVolts(VBAT_ADC_PIN);
+    uint32_t millivolts = analogReadMilliVolts(ALS_ADC_CHANNEL);
 #endif
     const uint32_t upper_divider = 442;
     const uint32_t lower_divider = 160;


### PR DESCRIPTION
…orVoltage()

Could not get light sensor on FeatherS3 to work with Arduino 2.2.3 (which defines ESP_ARDUINO_VERSION_MAJOR as 3 (huh?)). Upon investigation I noticed that VBAT_ADC_PIN should have been ALS_ADC_CHANNEL - probably a cut & paste mistake from "float getBatteryVoltage()" just above this correction. This is my first pull request (ever) so if I am doing anything incorrectly let me know.