### PR TITLE
Fixed error in getLightSensorVoltage()

### DIFF
--- a/src/UMS3.h
+++ b/src/UMS3.h
@@ -174,7 +174,7 @@ public:
     uint32_t raw = adc1_get_raw(ALS_ADC_CHANNEL);
     uint32_t millivolts = esp_adc_cal_raw_to_voltage(raw, &adc_cal);
 #else
-    uint32_t millivolts = analogReadMilliVolts(VBAT_ADC_PIN);
+    uint32_t millivolts = analogReadMilliVolts(ALS_ADC_PIN);
 #endif
     const uint32_t upper_divider = 442;
     const uint32_t lower_divider = 160;


### PR DESCRIPTION
Fixed error in getLightSensorVoltage() where VBAT_ADC_PIN was being instead of ALS_ADC_PIN.  Looks like a copy/paste error.