### PR TITLE
Update from ADC_ATTEN_DB_11 to ADC_ATTEN_DB_12

### DIFF
--- a/src/UMS3.h
+++ b/src/UMS3.h
@@ -53,7 +53,7 @@ public:
 
 #if defined(ARDUINO_FEATHERS3)
 #if ESP_ARDUINO_VERSION_MAJOR < 3
-    adc1_config_channel_atten(ALS_ADC_CHANNEL, ADC_ATTEN_DB_11);
+    adc1_config_channel_atten(ALS_ADC_CHANNEL, ADC_ATTEN_DB_12);
 #else
     analogSetPinAttenuation(ALS_ADC_PIN, ADC_11db);
 #endif


### PR DESCRIPTION
`ADC_ATTEN_DB_11` is deprecated and `ADC_ATTEN_DB_12` should be used instead

[Espressif Doc Link](https://docs.espressif.com/projects/esp-idf/en/v5.3.1/esp32/api-reference/peripherals/adc_oneshot.html#_CPPv4N11adc_atten_t15ADC_ATTEN_DB_11E)